### PR TITLE
rawdb: implement larry interface

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1542,92 +1542,181 @@ func benchmarkLarryGet(ctx context.Context, b *testing.B, dbFunc NewDBFunc) {
 	}
 }
 
-func RunRawDBTests(ctx context.Context, rdb larry.Database, table string) error {
-	blockSize := int64(4096)
+var RawDBTestBlockSize = int64(4096)
 
-	// Negative checks
-	_, err := rdb.Get(ctx, table, []byte("test"))
-	if !errors.Is(err, larry.ErrKeyNotFound) {
-		return fmt.Errorf("expected err %w, got %w", larry.ErrKeyNotFound, err)
-	}
-
-	has, err := rdb.Has(ctx, table, []byte("test"))
-	if err != nil {
-		return fmt.Errorf("%T %w", err, err)
-	}
-	if has {
-		return errors.New("has: expected key not found")
-	}
-
-	// Positive Checks
-	key := []byte("key")
-	data := []byte("hello, world!")
-	err = rdb.Put(ctx, table, key, data)
-	if err != nil {
-		return fmt.Errorf("%T %w", err, err)
-	}
-	KEY := []byte("KEY")
-	DATA := []byte("HELLO, WORLD!")
-	err = rdb.Put(ctx, table, KEY, DATA)
-	if err != nil {
-		return err
-	}
-
-	// Get data out again
-	dataRead, err := rdb.Get(ctx, table, key)
-	if err != nil {
-		return err
-	}
-	if !bytes.Equal(data, dataRead) {
-		return errors.New("data not identical")
-	}
-
-	has, err = rdb.Has(ctx, table, key)
-	if err != nil {
-		return fmt.Errorf("%T %w", err, err)
-	}
-	if !has {
-		return fmt.Errorf("key not found: %v", key)
-	}
-
-	dataRead, err = rdb.Get(ctx, table, KEY)
-	if err != nil {
-		return err
-	}
-	if !bytes.Equal(DATA, dataRead) {
-		return errors.New("data not identical")
-	}
-
-	has, err = rdb.Has(ctx, table, KEY)
-	if err != nil {
-		return fmt.Errorf("%T %w", err, err)
-	}
-	if !has {
-		return fmt.Errorf("key not found: %v", KEY)
-	}
-
-	// Overflow to next file
-	overflowData := make([]byte, int(blockSize)-len(data)-len(DATA)+1)
-	for k := range overflowData {
-		k = k % (math.MaxUint8 + 1)
-		if k < 0 || k > math.MaxUint8 {
-			return fmt.Errorf("uint8 overflow: %v", k)
+func RunRawDBTests(t *testing.T, dbFunc NewDBFunc, distributed bool) {
+	ctx := t.Context()
+	const insertCount = 10
+	t.Run("basic", func(t *testing.T) {
+		if !distributed {
+			t.Parallel()
 		}
-		overflowData[k] = uint8(k)
-	}
-	overflowKey := []byte("overflow")
-	err = rdb.Put(ctx, table, overflowKey, overflowData)
-	if err != nil {
-		return err
-	}
-	overflowRead, err := rdb.Get(ctx, table, overflowKey)
-	if err != nil {
-		return err
-	}
-	if !bytes.Equal(overflowData, overflowRead) {
-		return errors.New("overflow data not identical")
-	}
-	return nil
+
+		db, tables := prepareTestSuite(ctx, t, 1, 0, dbFunc, nil)
+		defer func() {
+			err := db.Close(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// Already Open
+		if err := db.Open(ctx); err == nil {
+			t.Fatal("expected already open error")
+		}
+
+		// Put Empty
+		err := dbputEmpty(ctx, db, tables)
+		if err != nil {
+			t.Fatalf("dbputEmpty: %v", err)
+		}
+
+		// Put Invalid Table
+		err = dbputInvalidTable(ctx, db, fmt.Sprintf("table%d", len(tables)))
+		if err != nil {
+			t.Fatalf("dbputInvalidTable: %v", err)
+		}
+
+		// Has negative
+		err = dbhasNegative(ctx, db, tables, insertCount)
+		if err != nil {
+			t.Fatalf("dbhasNegative: %v", err)
+		}
+
+		// Get negative
+		err = dbgetsNegative(ctx, db, tables, insertCount)
+		if err != nil {
+			t.Fatalf("dbgetsNegative: %v", err)
+		}
+
+		// Puts
+		err = dbputs(ctx, db, tables, insertCount)
+		if err != nil {
+			t.Fatalf("dbputs: %v", err)
+		}
+
+		// Get Invalid Table
+		err = dbgetInvalidTable(ctx, db, fmt.Sprintf("table%d", len(tables)))
+		if err != nil {
+			t.Fatalf("dbgetInvalidTable: %v", err)
+		}
+
+		// Get
+		err = dbgets(ctx, db, tables, insertCount)
+		if err != nil {
+			t.Fatalf("dbgets: %v", err)
+		}
+
+		// Has Invalid Table
+		err = dbhasInvalidTable(ctx, db, fmt.Sprintf("table%d", len(tables)))
+		if err != nil {
+			t.Fatalf("dbgetInvalidTable: %v", err)
+		}
+
+		// Has
+		err = dbhas(ctx, db, tables, insertCount)
+		if err != nil {
+			t.Fatalf("dbhas: %v", err)
+		}
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		if !distributed {
+			t.Parallel()
+		}
+
+		rdb, tables := prepareTestSuite(ctx, t, 1, 0, dbFunc, nil)
+		defer func() {
+			err := rdb.Close(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+		table := tables[0]
+
+		// Negative checks
+		_, err := rdb.Get(ctx, table, []byte("test"))
+		if !errors.Is(err, larry.ErrKeyNotFound) {
+			t.Fatalf("expected err %v, got %v", larry.ErrKeyNotFound, err)
+		}
+
+		has, err := rdb.Has(ctx, table, []byte("test"))
+		if err != nil {
+			t.Fatalf("%T %v", err, err)
+		}
+		if has {
+			t.Fatalf("has: expected key not found")
+		}
+
+		// Positive Checks
+		key := []byte("key")
+		data := []byte("hello, world!")
+		err = rdb.Put(ctx, table, key, data)
+		if err != nil {
+			t.Fatalf("%T %v", err, err)
+		}
+		KEY := []byte("KEY")
+		DATA := []byte("HELLO, WORLD!")
+		err = rdb.Put(ctx, table, KEY, DATA)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Get data out again
+		dataRead, err := rdb.Get(ctx, table, key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(data, dataRead) {
+			t.Fatalf("data not identical")
+		}
+
+		has, err = rdb.Has(ctx, table, key)
+		if err != nil {
+			t.Fatalf("%T %v", err, err)
+		}
+		if !has {
+			t.Fatalf("key not found: %v", key)
+		}
+
+		dataRead, err = rdb.Get(ctx, table, KEY)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(DATA, dataRead) {
+			t.Fatalf("data not identical")
+		}
+
+		has, err = rdb.Has(ctx, table, KEY)
+		if err != nil {
+			t.Fatalf("%T %v", err, err)
+		}
+		if !has {
+			t.Fatalf("key not found: %v", KEY)
+		}
+
+		// Overflow to next file
+		overflowData := make([]byte, int(RawDBTestBlockSize)-len(data)-len(DATA)+1)
+		for k := range overflowData {
+			k = k % (math.MaxUint8 + 1)
+			if k < 0 || k > math.MaxUint8 {
+				t.Fatalf("uint8 overflow: %v", k)
+			}
+			overflowData[k] = uint8(k)
+		}
+		overflowKey := []byte("overflow")
+		err = rdb.Put(ctx, table, overflowKey, overflowData)
+		if err != nil {
+			t.Fatal(err)
+		}
+		overflowRead, err := rdb.Get(ctx, table, overflowKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(overflowData, overflowRead) {
+			t.Fatalf("overflow data not identical")
+		}
+	})
 }
 
 // TODO extra tests

--- a/larry/clickhouse/clickhouse_test.go
+++ b/larry/clickhouse/clickhouse_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Hemi Labs, Inc.
+// Copyright (c) 2025-2026 Hemi Labs, Inc.
 // Use of this source code is governed by the MIT License,
 // which can be found in the LICENSE file.
 

--- a/larry/multi/multi.go
+++ b/larry/multi/multi.go
@@ -43,6 +43,7 @@ import (
 	"github.com/hemilabs/larry/larry"
 	"github.com/hemilabs/larry/larry/leveldb"
 	"github.com/hemilabs/larry/larry/pebble"
+	"github.com/hemilabs/larry/larry/rawdb"
 )
 
 const (
@@ -51,6 +52,7 @@ const (
 
 	TypeLevelDB  = "leveldb"
 	TypePebbleDB = "pebble"
+	TypeRawDB    = "rawdb"
 )
 
 var log = loggo.GetLogger("multi")
@@ -112,6 +114,9 @@ func (b *multiDB) openDB(ctx context.Context, db, name string) error {
 	case TypePebbleDB:
 		cfg := pebble.DefaultPebbleConfig(bhs, []string{dbname})
 		bhsDB, err = pebble.NewPebbleDB(cfg)
+	case TypeRawDB:
+		cfg := rawdb.DefaultRawDBConfig(bhs, dbname)
+		bhsDB, err = rawdb.NewRawDB(cfg)
 	default:
 		err = fmt.Errorf("unsupported db type: %v", db)
 	}

--- a/larry/multi/multi_test.go
+++ b/larry/multi/multi_test.go
@@ -5,6 +5,7 @@
 package multi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hemilabs/larry/internal/testutil"
@@ -27,6 +28,28 @@ var dbFunc = func(home string, tables []string, _ map[string]string) larry.Datab
 func TestMultiDB(t *testing.T) {
 	t.Parallel()
 	testutil.RunLarryTests(t, dbFunc, false)
+}
+
+func TestMultiRawDB(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	table := "testtable"
+	tables := map[string]string{table: TypeRawDB}
+	cfg := DefaultMultiConfig(t.TempDir(), tables)
+	rdb, err := NewMultiDB(cfg)
+	if err != nil {
+		panic(err)
+	}
+	if err := rdb.Open(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testutil.RunRawDBTests(ctx, rdb, table); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func BenchmarkMultiDB(b *testing.B) {

--- a/larry/rawdb/rawdb.go
+++ b/larry/rawdb/rawdb.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hemilabs/larry/larry"
 	"github.com/hemilabs/larry/larry/leveldb"
+	"github.com/hemilabs/larry/larry/pebble"
 )
 
 const (
@@ -117,6 +118,10 @@ func (r *rawDB) Open(ctx context.Context) error {
 		lcfg := leveldb.DefaultLevelDBConfig(filepath.Join(r.cfg.Home, indexDir),
 			r.cfg.Tables)
 		r.index, err = leveldb.NewLevelDB(lcfg)
+	case TypePebble:
+		lcfg := pebble.DefaultPebbleConfig(filepath.Join(r.cfg.Home, indexDir),
+			r.cfg.Tables)
+		r.index, err = pebble.NewPebbleDB(lcfg)
 	default:
 	}
 	if err != nil {
@@ -158,7 +163,7 @@ func (r *rawDB) DB() larry.Database {
 	return r.index
 }
 
-func (b *rawDB) Del(_ context.Context, table string, key []byte) error {
+func (r *rawDB) Del(_ context.Context, _ string, _ []byte) error {
 	return larry.ErrNotSupported
 }
 
@@ -310,26 +315,26 @@ func (r *rawDB) Get(ctx context.Context, table string, key []byte) ([]byte, erro
 	return data, nil
 }
 
-func (b *rawDB) Begin(_ context.Context, _ bool) (larry.Transaction, error) {
+func (r *rawDB) Begin(_ context.Context, _ bool) (larry.Transaction, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (b *rawDB) View(_ context.Context, _ func(_ context.Context, _ larry.Transaction) error) error {
+func (r *rawDB) View(_ context.Context, _ func(_ context.Context, _ larry.Transaction) error) error {
 	return larry.ErrNotSupported
 }
 
-func (b *rawDB) Update(_ context.Context, _ func(ctx context.Context, _ larry.Transaction) error) error {
+func (r *rawDB) Update(_ context.Context, _ func(ctx context.Context, _ larry.Transaction) error) error {
 	return larry.ErrNotSupported
 }
 
-func (b *rawDB) NewIterator(_ context.Context, _ string) (larry.Iterator, error) {
+func (r *rawDB) NewIterator(_ context.Context, _ string) (larry.Iterator, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (b *rawDB) NewRange(_ context.Context, _ string, _, _ []byte) (larry.Range, error) {
+func (r *rawDB) NewRange(_ context.Context, _ string, _, _ []byte) (larry.Range, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (b *rawDB) NewBatch(_ context.Context) (larry.Batch, error) {
+func (r *rawDB) NewBatch(_ context.Context) (larry.Batch, error) {
 	return nil, larry.ErrNotSupported
 }

--- a/larry/rawdb/rawdb.go
+++ b/larry/rawdb/rawdb.go
@@ -35,7 +35,7 @@ const (
 	DefaultMaxFileSize = 256 * 1024 * 1024 // 256MB file max; will never be bigger.
 
 	TypeLevelDB    = "leveldb"
-	TypePebble     = "pebble"
+	TypePebbleDB   = "pebble"
 	TypeClickhouse = "clickhouse"
 )
 
@@ -80,6 +80,7 @@ func DefaultRawDBConfig(home, remoteURI string) *Config {
 		MaxSize:   DefaultMaxFileSize,
 		Table:     DefaultTable,
 		RemoteURI: remoteURI,
+		DB:        TypeLevelDB,
 	}
 }
 
@@ -97,7 +98,7 @@ func NewRawDB(cfg *Config) (larry.Database, error) {
 
 	switch cfg.DB {
 	case TypeLevelDB:
-	case TypePebble:
+	case TypePebbleDB:
 	case TypeClickhouse:
 		if cfg.Table == "" {
 			return nil,
@@ -133,7 +134,7 @@ func (r *RawDB) Open(ctx context.Context) error {
 		lcfg := leveldb.DefaultLevelDBConfig(filepath.Join(r.cfg.Home, indexDir),
 			[]string{r.cfg.Table})
 		r.index, err = leveldb.NewLevelDB(lcfg)
-	case TypePebble:
+	case TypePebbleDB:
 		lcfg := pebble.DefaultPebbleConfig(filepath.Join(r.cfg.Home, indexDir),
 			[]string{r.cfg.Table})
 		r.index, err = pebble.NewPebbleDB(lcfg)

--- a/larry/rawdb/rawdb.go
+++ b/larry/rawdb/rawdb.go
@@ -51,9 +51,9 @@ func init() {
 }
 
 // Assert required interfaces
-var _ larry.Database = (*rawDB)(nil)
+var _ larry.Database = (*RawDB)(nil)
 
-type rawDB struct {
+type RawDB struct {
 	mtx sync.RWMutex
 
 	cfg *Config
@@ -107,12 +107,12 @@ func NewRawDB(cfg *Config) (larry.Database, error) {
 		return nil, fmt.Errorf("invalid db: %v", cfg.DB)
 	}
 
-	return &rawDB{
+	return &RawDB{
 		cfg: cfg,
 	}, nil
 }
 
-func (r *rawDB) Open(ctx context.Context) error {
+func (r *RawDB) Open(ctx context.Context) error {
 	log.Tracef("Open")
 	defer log.Tracef("Open exit")
 
@@ -156,7 +156,7 @@ func (r *rawDB) Open(ctx context.Context) error {
 	return nil
 }
 
-func (r *rawDB) Close(ctx context.Context) error {
+func (r *RawDB) Close(ctx context.Context) error {
 	log.Tracef("Close")
 	defer log.Tracef("Close exit")
 
@@ -178,22 +178,22 @@ func (r *rawDB) Close(ctx context.Context) error {
 // DB returns the underlying index database.
 // You should probably not be calling this! It is used for external database
 // upgrades.
-func (r *rawDB) DB() larry.Database {
+func (r *RawDB) DB() larry.Database {
 	return r.index
 }
 
-func (r *rawDB) Del(_ context.Context, _ string, _ []byte) error {
+func (r *RawDB) Del(_ context.Context, _ string, _ []byte) error {
 	return larry.ErrNotSupported
 }
 
-func (r *rawDB) Has(ctx context.Context, table string, key []byte) (bool, error) {
+func (r *RawDB) Has(ctx context.Context, table string, key []byte) (bool, error) {
 	log.Tracef("Has")
 	defer log.Tracef("Has exit")
 
 	return r.index.Has(ctx, table, key)
 }
 
-func (r *rawDB) Put(ctx context.Context, table string, key, value []byte) error {
+func (r *RawDB) Put(ctx context.Context, table string, key, value []byte) error {
 	log.Tracef("Put")
 	defer log.Tracef("Put exit")
 
@@ -295,7 +295,7 @@ func (r *rawDB) Put(ctx context.Context, table string, key, value []byte) error 
 	}
 }
 
-func (r *rawDB) Get(ctx context.Context, table string, key []byte) ([]byte, error) {
+func (r *RawDB) Get(ctx context.Context, table string, key []byte) ([]byte, error) {
 	log.Tracef("Get: %x", key)
 	defer log.Tracef("Get exit: %x", key)
 
@@ -334,26 +334,26 @@ func (r *rawDB) Get(ctx context.Context, table string, key []byte) ([]byte, erro
 	return data, nil
 }
 
-func (r *rawDB) Begin(_ context.Context, _ bool) (larry.Transaction, error) {
+func (r *RawDB) Begin(_ context.Context, _ bool) (larry.Transaction, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (r *rawDB) View(_ context.Context, _ func(_ context.Context, _ larry.Transaction) error) error {
+func (r *RawDB) View(_ context.Context, _ func(_ context.Context, _ larry.Transaction) error) error {
 	return larry.ErrNotSupported
 }
 
-func (r *rawDB) Update(_ context.Context, _ func(ctx context.Context, _ larry.Transaction) error) error {
+func (r *RawDB) Update(_ context.Context, _ func(ctx context.Context, _ larry.Transaction) error) error {
 	return larry.ErrNotSupported
 }
 
-func (r *rawDB) NewIterator(_ context.Context, _ string) (larry.Iterator, error) {
+func (r *RawDB) NewIterator(_ context.Context, _ string) (larry.Iterator, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (r *rawDB) NewRange(_ context.Context, _ string, _, _ []byte) (larry.Range, error) {
+func (r *RawDB) NewRange(_ context.Context, _ string, _, _ []byte) (larry.Range, error) {
 	return nil, larry.ErrNotSupported
 }
 
-func (r *rawDB) NewBatch(_ context.Context) (larry.Batch, error) {
+func (r *RawDB) NewBatch(_ context.Context) (larry.Batch, error) {
 	return nil, larry.ErrNotSupported
 }

--- a/larry/rawdb/rawdb_test.go
+++ b/larry/rawdb/rawdb_test.go
@@ -30,7 +30,10 @@ func testRawDB(t *testing.T, dbs string) {
 	}()
 
 	blockSize := int64(4096)
-	rdb, err := NewRawDB(&Config{DB: dbs, Home: home, MaxSize: blockSize})
+	rdb, err := NewRawDB(&Config{
+		DB: dbs, Home: home, MaxSize: blockSize,
+		Tables: []string{DefaultTable},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/larry/rawdb/rawdb_test.go
+++ b/larry/rawdb/rawdb_test.go
@@ -57,8 +57,10 @@ func testRawDB(t *testing.T, dbs, remoteURI string) {
 	if dbs != TypeClickhouse {
 		// Open again and expect locked failure
 		rdb2, err := NewRawDB(
-			&Config{DB: dbs, Home: home, MaxSize: blockSize, RemoteURI: remoteURI,
-				Table: table})
+			&Config{
+				DB: dbs, Home: home, MaxSize: blockSize, RemoteURI: remoteURI,
+				Table: table,
+			})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/larry/rawdb/rawdb_test.go
+++ b/larry/rawdb/rawdb_test.go
@@ -30,7 +30,7 @@ func testRawDB(t *testing.T, dbs string) {
 	}()
 
 	blockSize := int64(4096)
-	rdb, err := New(&Config{DB: dbs, Home: home, MaxSize: blockSize})
+	rdb, err := NewRawDB(&Config{DB: dbs, Home: home, MaxSize: blockSize})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func testRawDB(t *testing.T, dbs string) {
 
 	if dbs != "mongo" {
 		// Open again and expect locked failure
-		rdb2, err := New(&Config{DB: dbs, Home: home, MaxSize: blockSize})
+		rdb2, err := NewRawDB(&Config{DB: dbs, Home: home, MaxSize: blockSize})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -59,26 +59,26 @@ func testRawDB(t *testing.T, dbs string) {
 
 	key := []byte("key")
 	data := []byte("hello, world!")
-	err = rdb.Insert(ctx, key, data)
+	err = rdb.Put(ctx, DefaultTable, key, data)
 	if err != nil {
 		t.Fatalf("%T %v", err, err)
 	}
 	KEY := []byte("KEY")
 	DATA := []byte("HELLO, WORLD!")
-	err = rdb.Insert(ctx, KEY, DATA)
+	err = rdb.Put(ctx, DefaultTable, KEY, DATA)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Get data out again
-	dataRead, err := rdb.Get(ctx, key)
+	dataRead, err := rdb.Get(ctx, DefaultTable, key)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !bytes.Equal(data, dataRead) {
 		t.Fatal("data not identical")
 	}
-	dataRead, err = rdb.Get(ctx, KEY)
+	dataRead, err = rdb.Get(ctx, DefaultTable, KEY)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,11 +96,11 @@ func testRawDB(t *testing.T, dbs string) {
 		overflowData[k] = uint8(k)
 	}
 	overflowKey := []byte("overflow")
-	err = rdb.Insert(ctx, overflowKey, overflowData)
+	err = rdb.Put(ctx, DefaultTable, overflowKey, overflowData)
 	if err != nil {
 		t.Fatal(err)
 	}
-	overflowRead, err := rdb.Get(ctx, overflowKey)
+	overflowRead, err := rdb.Get(ctx, DefaultTable, overflowKey)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ensures `RawDB` adheres to the Larry interface while retaining its core functionalities. This will allow `RawDB` to be used with `multiDB`. Only the `put`, `has`, and `get` methods are available, in accordance with the original design. All other methods return a `NotSupported` error.

**NOTE**: further testing of `multiDB` with `RawDB` set up requires issue #19 to be addressed, and will be added in the future. 